### PR TITLE
Enable multi_instance

### DIFF
--- a/check_process
+++ b/check_process
@@ -40,7 +40,7 @@
 		# 1.15.1~ynh2
 		upgrade=1	from_commit=2a0a768ba1e8c93c2cd1b3ef97ac558c86ddc72c
 		backup_restore=1
-		multi_instance=0
+		multi_instance=1
 		port_already_use=0
 		change_url=1
 ;;; Options

--- a/conf/config.xml
+++ b/conf/config.xml
@@ -10,7 +10,8 @@
         <insecureSkipVerify>false</insecureSkipVerify>
     </ldap>
     <options>
-        <listenAddress>default</listenAddress>
+        <listenAddress>tcp://0.0.0.0:__SYNC_PORT__</listenAddress>
+        <listenAddress>quic://0.0.0.0:__SYNC_PORT__</listenAddress>
         <globalAnnounceServer>default</globalAnnounceServer>
         <globalAnnounceEnabled>true</globalAnnounceEnabled>
         <localAnnounceEnabled>true</localAnnounceEnabled>

--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,7 @@
     "requirements": {
         "yunohost": ">= 4.1.3"
     },
-    "multi_instance": false,
+    "multi_instance": true,
     "services": [
         "nginx"
     ],

--- a/scripts/install
+++ b/scripts/install
@@ -143,7 +143,7 @@ chown -R $app: $final_path
 
 ynh_systemd_action --service_name=$app --action="start" --log_path=systemd --line_match="Access the GUI via the following URL"
 
-ynh_replace_string --match_string="<listenAddress>tcp://default</listenAddress>" --replace_string="<listenAddress>default</listenAddress>" --target_file="$config_file"
+ynh_replace_string --match_string="<listenAddress>tcp://quic:%2F%2F0.0.0.0:$sync_port</listenAddress>" --replace_string="<listenAddress>quic//0.0.0.0:$sync_port</listenAddress>" --target_file="$config_file"
 
 ynh_systemd_action --service_name=$app --action="stop" --log_path=systemd
 


### PR DESCRIPTION
[This thread](https://forum.yunohost.org/t/syncthing-multi-utilisateur/16372) on the forum got me trying installing multiple instances of Syncthing, and it seems to be working!

I concede that being forced to have one app per user is not ideal, but we are constrained with Syncthing's own design. I am sure there are plenty of use cases for this.

Tested without issues:
- [x] Two instances sharing files locally
- [x] Two instances locally, one of which sharing files externally