### PR TITLE
fix: create armel source

### DIFF
--- a/conf/armel.src
+++ b/conf/armel.src
@@ -1,0 +1,6 @@
+SOURCE_URL=https://github.com/syncthing/syncthing/releases/download/v1.22.1/syncthing-linux-arm-v1.22.1.tar.gz
+SOURCE_SUM=6506b24baa1cc22b088e4cf0b67eb738dc813f4b23865d8b8ff0456a2c2efa0b
+SOURCE_SUM_PRG=sha256sum
+SOURCE_FORMAT=tar.gz
+SOURCE_IN_SUBDIR=true
+SOURCE_FILENAME=


### PR DESCRIPTION
## Problem

The armel architecture is not supported

## Solution

Simply clone the arm.

Fixes #134 

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
