### PR TITLE
use double dash for long options

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 User=__APP__
-ExecStart=__INSTALL_DIR__/syncthing -no-browser -no-restart -logflags=0
+ExecStart=__INSTALL_DIR__/syncthing --no-browser --no-restart --logflags=0
 Restart=on-failure
 SuccessExitStatus=3 4
 RestartForceExitStatus=3 4


### PR DESCRIPTION
syncthing now only accepts double dashes for long options

## Problem

- syncthing.service exits immediately with error "syncthing: error: unknown flag -n, did you mean one of "-h", "-C", "-D", "-H"?"

## Solution

- Use double-dash for long options

## PR Status

- [ X ] Code finished and ready to be reviewed/tested
- [ X ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
