### PR TITLE
Fix upgrading with multiple installations of the application

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -16,11 +16,11 @@ ynh_systemctl --service=$app --action="stop" --log_path=systemd
 ynh_script_progression "Upgrading source files..."
 
 # Download, check integrity, uncompress and patch the source from app.src
-ynh_setup_source --dest_dir="$install_dir" --keep=".config/$app/config.xml"
+ynh_setup_source --dest_dir="$install_dir" --keep=".config/syncthing/config.xml"
 
 if ynh_app_upgrading_from_version_before 2.0.16~ynh2
 then
-  ynh_replace --match="<authMode>ldap</authMode>" --replace="<authMode>ldap</authMode>\n          <insecureSkipHostcheck>true</insecureSkipHostcheck>" --file="$install_dir/.config/$app/config.xml"
+  ynh_replace --match="<authMode>ldap</authMode>" --replace="<authMode>ldap</authMode>\n          <insecureSkipHostcheck>true</insecureSkipHostcheck>" --file="$install_dir/.config/syncthing/config.xml"
 fi
 
 


### PR DESCRIPTION
## Problem

- Upgrade from 2.0.X versions to 2.1.0 fail when multiple instances of syncthing are installed with different names - https://github.com/YunoHost-Apps/syncthing_ynh/issues/254.

## Solution

- Fixing the paths to the `config.xml` file so that it always uses `syncthing/` sub-directory, irrespectively to whether the application can have a different name at a specific Yunohost installation.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
